### PR TITLE
Issue #55 - DirTree changes in 2.8

### DIFF
--- a/src/general/DirTree.md
+++ b/src/general/DirTree.md
@@ -129,7 +129,7 @@ so that you can respond to double-clicks on files in the tree:
 
 ```java
 @Override
-void fileDoubleClicked(DirTree source, File file) {
+public void fileDoubleClicked(DirTree source, File file) {
     // A file was double-clicked in the tree
     // For example, we could open the file in an editor:
     openFileInEditor(file);
@@ -143,7 +143,7 @@ a hidden file is any file or directory whose name begins with a dot (`.`). With 
 opt to show these hidden directories, either programmatically, or via the popup menu:
 
 ```java
-// Let's hide hidden files (by default, they are shown):
+// Let's hide hidden files/dirs (by default, they are shown):
 myDirTree.setShowHidden(false);
 ```
 


### PR DESCRIPTION
This PR addresses issue #55 by updating the documentation for the `DirTree` component to reflect changes in the recent 2.8 release. Specifically, there is a new option (off by default) for viewing files in the DirTree as well as just directories.